### PR TITLE
Schema mod

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,27 @@ provided.  You cannot use `ownerField` and `ownerSelf` at the same time.
 * `ownerField` The name of the field in each mongo document that holds the owner id.
 * `ownerSelf` If true the object uses its own "_id" field as its ownerField.
 
+<h2>Schema Additives</h2>
+There are a few additional tags that Autocrud will read from JSON-Schemas.  These allow you to manipulate how Autocrud
+will present data to the user as well as how to validate data.  These tags will not interfere with the `json-schema`
+library's normal validation process.
+
+```javascript
+autocrud({
+	... // Default options
+	schema: {
+		type: 'object',
+		properties: {
+			username: {type: 'string', required: true},
+			password: {type: 'string', required: true, hidden: true}
+		}
+	}
+});
+```
+* `hidden` If a field is marked hidden it will have normal validation applied to it during POST and PUT calls, but will
+  not be returned to the user during GET calls.
+
+
 <h2>Events</h2>
 There are a handful of events that will be fired with http calls to the Autocrud object.
 
@@ -141,3 +162,7 @@ skip are provided.
 * `deleteId`
     *  `id` The id of the resource deleted.
     *  `modCount` The number of documents that were deleted.
+
+<h2>Breaking Changes</h2>
+* `>= 0.2.4` The POST function no longer returns a whole document when called.  Going forward it will only return a root
+  object that contains the ObjectID of the newly created document.


### PR DESCRIPTION
I've cleaned up most of the really ugly testing code in base.js.  Also, I've added the ability to mark fields as hidden, which will prevent them from ever being returned to the user.  For example, this would be useful if you are using Autocrud to build a user object.  You would want the user to be able to manipulate their user settings, but it should never be possible for a user to read their password out of the database, only update it.
